### PR TITLE
Remove needless "self"

### DIFF
--- a/lib/benchmark-config.rb
+++ b/lib/benchmark-config.rb
@@ -76,7 +76,7 @@ class BenchmarkConfig
       if obj.instance_of?(Hash)
         obj.merge!(value)
       else
-        self.send("#{key}=", value)
+        send("#{key}=", value)
       end
     end
   end


### PR DESCRIPTION
In this case, "self" reciever is needless, so I remove it.
(For example, when self#[] is called, "self" is needed.)
