### PR TITLE
Use more proper name

### DIFF
--- a/lib/benchmark-config.rb
+++ b/lib/benchmark-config.rb
@@ -70,8 +70,8 @@ class BenchmarkConfig
   end
 
   def load_file(path)
-    file = YAML.load_file(path)
-    file.each do |key, value|
+    yaml = YAML.load_file(path)
+    yaml.each do |key, value|
       obj = send("#{key}")
       if obj.instance_of?(Hash)
         obj.merge!(value)


### PR DESCRIPTION
"file.each" is confused expression because objects containing "file" (block variable in #each) are vague.
