### PR TITLE
Use proper name to match objects

### DIFF
--- a/lib/benchmark-config.rb
+++ b/lib/benchmark-config.rb
@@ -70,8 +70,8 @@ class BenchmarkConfig
   end
 
   def load_file(path)
-    yaml = YAML.load_file(path)
-    yaml.each do |key, value|
+    config_items = YAML.load_file(path)
+    config_items.each do |key, value|
       obj = send("#{key}")
       if obj.instance_of?(Hash)
         obj.merge!(value)


### PR DESCRIPTION
An object loaded by #load_file isn't YAML yet, so I revice the variable name again. Sorry...
