### PR TITLE
Remove duplicated condition branch

### DIFF
--- a/lib/benchmark-result.rb
+++ b/lib/benchmark-result.rb
@@ -41,7 +41,7 @@ class BenchmarkResult
   def add(row)
     @rows << row
     FileUtils.mkdir_p(File.dirname(@path))
-    output_header
+    output_header unless @has_header
     output_row(row)
   end
 
@@ -59,7 +59,6 @@ class BenchmarkResult
 
   private
   def output_header
-    return if @has_header
     output_row
     @has_header = true
   end

--- a/lib/benchmark-result.rb
+++ b/lib/benchmark-result.rb
@@ -41,7 +41,7 @@ class BenchmarkResult
   def add(row)
     @rows << row
     FileUtils.mkdir_p(File.dirname(@path))
-    output_header unless @has_header
+    output_header
     output_row(row)
   end
 


### PR DESCRIPTION
The caller(#add) doesn't have to check if the result has the header, because the #output_header checks it already. I think #output_header has the responsibility to output header.
