### PR TITLE
Use $stderr instead of STDERR

### DIFF
--- a/lib/zabbix-log.rb
+++ b/lib/zabbix-log.rb
@@ -88,8 +88,8 @@ class ZabbixLog
       FileUtils.mkdir_p(File.dirname(dest))
       FileUtils.mv(src, dest)
     rescue
-      STDERR.puts("Warning: Failed to move #{src} to #{dest}! " +
-                  "Please check the permission.")
+      $stderr.puts("Warning: Failed to move #{src} to #{dest}! " +
+                     "Please check the permission.")
     end
   end
 


### PR DESCRIPTION
$stderr is more proper because STDERR is the default standard error,
on the other hand, $stderr is one used by present process.

(Then, this commit also fix indent of the continuous string.)
